### PR TITLE
fix: DB 필드 명세 재설정

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,34 +8,34 @@ datasource db {
 }
 
 model chat {
-  id              Int       @id(map: "table_name_pkey") @unique @default(autoincrement())
-  user_id         Int?
-  question_type   String?   @db.VarChar(10)
-  question_number Int?
-  answer          String?
+  id              Int      @id(map: "table_name_pkey") @unique @default(autoincrement())
+  user_id         Int
+  question_type   String   @db.VarChar(1)
+  question_number Int
+  answer          String   @db.VarChar(100)
   grade           Int?
-  createdAt       DateTime  @default(now())
-  updatedAt       DateTime  @updatedAt
-  team_id         Int?
-  nickname        nickname? @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_nickname_id_fk")
-  team            team?     @relation(fields: [team_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_team_id_fk")
+  createdAt       DateTime @default(dbgenerated("CURRENT_DATE")) @db.Date
+  updatedAt       DateTime @updatedAt @db.Date
+  team_id         Int
+  nickname        nickname @relation(fields: [user_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_nickname_id_fk")
+  team            team     @relation(fields: [team_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_team_id_fk")
 }
 
 model nickname {
   id        Int        @id(map: "user_pkey") @unique @default(autoincrement())
-  name      String     @db.VarChar(50)
-  createdAt DateTime   @default(now())
-  updatedAt DateTime   @updatedAt
+  name      String     @unique @db.VarChar(4)
+  createdAt DateTime   @default(dbgenerated("CURRENT_DATE")) @db.Date
+  updatedAt DateTime   @updatedAt @db.Date
   chat      chat[]
   team_user team_user?
 }
 
 model team {
-  id          Int         @id
-  team_name   String      @db.VarChar(100)
+  id          Int         @id @unique
+  team_name   String      @db.VarChar(14)
   team_member Int
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  createdAt   DateTime    @default(dbgenerated("CURRENT_DATE")) @db.Date
+  updatedAt   DateTime    @updatedAt @db.Date
   chat        chat[]
   team_user   team_user[]
 }


### PR DESCRIPTION
## Solved Issue

close #25 

## Motivation

- 성능 및 저장공간 낭비를 방지하기 위해 DB 필드 명세를 재설정합니다. 아마도..?

## Key Changes

- **nickname table**

기획의 의도에 맞게 닉네임은 중복 불가해야하므로 , unique처리를 해주었습니다.
닉네임 글자도 기획의 의도에 맞게 4글자여야 하므로 varchar(4)로 처리했습니다. 바이트값인줄 알았는데, 한 글자여서 신기했습니다.

- **chat table**

user_id는 chat table에서 unique가 아니라 중복된 값으로 가지고 있어야하므로 unique 처리를 하지 않습니다.
questionType은 영어 한글자만 들어가므로 varchar(1)로 처리했습니다.
answer가 최대 100자이므로 varchar(100)으로 처리했습니다.

- **Team table**
Team 이름도 기획의 의도에 맞게 최대 14자까지 가능하므로 varchar(14)로 처리했습니다

- etc
createdAt , updatedAt 에서 날짜 값만 가지고 있어도 되어서 타입을 DATETIME -> DATE로 변경하였습니다.

## To Reviewers

-  확인 부탁드려요~