### PR TITLE
fix: 카카오 사용자 정보 조회 시, 이름 가져오기

### DIFF
--- a/src/config/auth.ts
+++ b/src/config/auth.ts
@@ -14,7 +14,7 @@ const kakaoAuth = async (kakaoAccessToken: string) => {
     });
     const userId = user.data.id.toString();
     if (!userId) return exceptionMessage.INVALID_USER;
-    const name = user.data.kakao_account.name;
+    const name = user.data.kakao_account.profile.nickname;
     const email = user.data.kakao_account.email;
 
     const kakaoUser: SocialUser = {


### PR DESCRIPTION
## Solved Issue

close #78

<br>

## Motivation

- 카카오 소셜 로그인 시 , 사용자 정보 조회할 때 이름을 불러오지 못합니다

<br>

## Key Changes

- axios 통신 후, 카카오 사용자 정보를 조회하는 api에서 메소드를 변경해주었습니다

<br>

## To Reviewers

- 머지해주세요~
