### PR TITLE
feat: 지난 티타임 조회 & auth 로직 추가

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,9 +35,11 @@ model team {
 model team_user {
   userId      Int
   teamId      Int
-  isCompleted Boolean @default(false)
-  team        team    @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_team_id_fk")
-  user        user    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
+  isCompleted Boolean   @default(false)
+  createdAt   DateTime? @default(dbgenerated("CURRENT_DATE")) @db.Date
+  updatedAt   DateTime? @updatedAt @db.Date
+  user        user      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
+  team        team      @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_team_id_fk")
 
   @@id([userId, teamId], map: "team_user_pk")
   @@unique([userId, teamId])

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,7 +36,7 @@ model team_user {
   id          Int     @id @default(autoincrement())
   userId      Int
   teamId      Int
-  isCompleted Boolean
+  isCompleted Boolean @default(false)
   user        user    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
   team        team    @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "team_user_team_id_fk")
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,12 +33,14 @@ model team {
 }
 
 model team_user {
-  id          Int     @id @default(autoincrement())
   userId      Int
   teamId      Int
   isCompleted Boolean @default(false)
+  team        team    @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_team_id_fk")
   user        user    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
-  team        team    @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "team_user_team_id_fk")
+
+  @@id([userId, teamId], map: "team_user_pk")
+  @@unique([userId, teamId])
 }
 
 model user {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,7 +17,7 @@ model chat {
   createdAt      DateTime @default(dbgenerated("CURRENT_DATE")) @db.Date
   updatedAt      DateTime @updatedAt @db.Date
   teamId         Int
-  user           nickname @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_nickname_id_fk")
+  user           user     @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "chat_nickname_id_fk")
   team           team     @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "chat_team_id_fk")
 }
 
@@ -33,30 +33,16 @@ model team {
 }
 
 model team_user {
-  id          Int      @id @default(autoincrement())
-  userId      Int      @unique(map: "team_user_user_id_key")
+  id          Int     @id @default(autoincrement())
+  userId      Int     @unique(map: "team_user_user_id_key")
   teamId      Int
   isCompleted Boolean
-  user        nickname @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
-  team        team     @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "team_user_team_id_fk")
+  user        user    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
+  team        team    @relation(fields: [teamId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "team_user_team_id_fk")
 }
 
-model personal_result {
-  id            Int     @id @default(autoincrement())
-  userId        Int?
-  teamId        Int?
-  date          String? @db.Char(1)
-  result        String? @db.Char(1)
-  collaboration Int?
-  personalLife  Int?
-  health        Int?
-  development   Int?
-  motivation    Int?
-  teamName      String? @db.Char(1)
-}
-
-model nickname {
-  id           Int        @id(map: "user_pkey") @unique @default(autoincrement())
+model user {
+  id           Int        @id @unique(map: "nickname_id_key") @default(autoincrement())
   name         String     @db.VarChar(4)
   createdAt    DateTime   @default(dbgenerated("CURRENT_DATE")) @db.Date
   updatedAt    DateTime?  @default(dbgenerated("CURRENT_DATE")) @db.Date

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -34,7 +34,7 @@ model team {
 
 model team_user {
   id          Int     @id @default(autoincrement())
-  userId      Int     @unique(map: "team_user_user_id_key")
+  userId      Int
   teamId      Int
   isCompleted Boolean
   user        user    @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
@@ -42,14 +42,14 @@ model team_user {
 }
 
 model user {
-  id           Int        @id @unique(map: "nickname_id_key") @default(autoincrement())
-  name         String     @db.VarChar(4)
-  createdAt    DateTime   @default(dbgenerated("CURRENT_DATE")) @db.Date
-  updatedAt    DateTime?  @default(dbgenerated("CURRENT_DATE")) @db.Date
-  social       String?    @db.VarChar(10)
-  snsId        String?    @db.VarChar
-  email        String?    @db.VarChar(40)
-  refreshToken String?    @db.VarChar(200)
+  id           Int         @id @unique(map: "nickname_id_key") @default(autoincrement())
+  name         String      @db.VarChar(4)
+  createdAt    DateTime    @default(dbgenerated("CURRENT_DATE")) @db.Date
+  updatedAt    DateTime?   @default(dbgenerated("CURRENT_DATE")) @db.Date
+  social       String?     @db.VarChar(10)
+  snsId        String?     @db.VarChar
+  email        String?     @db.VarChar(40)
+  refreshToken String?     @db.VarChar(200)
   chat         chat[]
-  team_user    team_user?
+  team_user    team_user[]
 }

--- a/src/controllers/chatController.ts
+++ b/src/controllers/chatController.ts
@@ -5,7 +5,7 @@ import { createAnswerDto } from '../interfaces/DTO';
 import { chatService } from '../services';
 
 const chatAnswer = async (req: Request, res: Response, next: NextFunction) => {
-  const { userId } = req.params;
+  const userId = res.locals.JwtPayload;
   const createAnswerDto: createAnswerDto = req.body;
   try {
     const data = await chatService.chatAnswer(+userId, createAnswerDto);

--- a/src/controllers/resultController.ts
+++ b/src/controllers/resultController.ts
@@ -90,12 +90,14 @@ const checkUserHappiness = async (
   res: Response,
   next: NextFunction,
 ) => {
-  const { userId } = req.params;
+  const userId = res.locals.JwtPayload;
+  const { teamId } = req.params;
   const checkUserHappinessDto: checkUserHappinessDto = req.body;
 
   try {
     const data = await resultService.checkUserHappiness(
       +userId,
+      +teamId,
       checkUserHappinessDto,
     );
     return res

--- a/src/controllers/resultController.ts
+++ b/src/controllers/resultController.ts
@@ -1,4 +1,7 @@
-import { checkUserHappinessDto, makePersonalResultDto } from '../interfaces/DTO';
+import {
+  checkUserHappinessDto,
+  makePersonalResultDto,
+} from '../interfaces/DTO';
 import { Request, Response, NextFunction } from 'express';
 import { message, statusCode } from '../modules/constants';
 import { success } from '../modules/constants/util';
@@ -103,33 +106,10 @@ const checkUserHappiness = async (
   }
 };
 
-const makePersonalResult = async (
-  req: Request,
-  res: Response,
-  next: NextFunction,
-) => {
-  const userId = res.locals.JwtPayload;
-  const makePersonalResultDto: makePersonalResultDto = req.body;
-
-  try {
-    const data = await resultService.makePersonalResult(
-      +userId,
-      makePersonalResultDto,
-    );
-    return res
-      .status(statusCode.OK)
-      .send(success(statusCode.OK, message.MAKE_PERSONAL_RESULT_SUCCESS, data));
-  } catch (error) {
-    next(error);
-  }
-};
-
-
 export default {
   userResult,
   teamResultByType,
   getTeamResultType,
   getTeamDetailResult,
   checkUserHappiness,
-  makePersonalResult,
 };

--- a/src/controllers/teamController.ts
+++ b/src/controllers/teamController.ts
@@ -1,4 +1,4 @@
-import { createTeamDto, participateTeamDto } from '../interfaces/DTO';
+import { createTeamDto } from '../interfaces/DTO';
 import { Request, Response, NextFunction } from 'express';
 import { message, statusCode } from '../modules/constants';
 import { success } from '../modules/constants/util';
@@ -26,11 +26,10 @@ const participateTeam = async (
   res: Response,
   next: NextFunction,
 ) => {
+  const userId = res.locals.JwtPayload;
   const { teamId } = req.params;
-  const participateTeamDto: participateTeamDto = req.body;
 
   try {
-    await teamService.duplicateName(+teamId, participateTeamDto);
     const data = await teamService.participateTeam(participateTeamDto, +teamId);
 
     return res

--- a/src/controllers/teamController.ts
+++ b/src/controllers/teamController.ts
@@ -6,11 +6,12 @@ import makeTeamId from '../modules/makeTeamId';
 import { teamService } from '../services';
 
 const makeTeam = async (req: Request, res: Response, next: NextFunction) => {
+  const userId = res.locals.JwtPayload;
   const createTeamDto: createTeamDto = req.body;
   const teamId = makeTeamId();
 
   try {
-    const data = await teamService.makeTeam(createTeamDto, teamId);
+    const data = await teamService.makeTeam(+userId, createTeamDto, teamId);
 
     return res
       .status(statusCode.CREATED)

--- a/src/controllers/teamController.ts
+++ b/src/controllers/teamController.ts
@@ -30,7 +30,7 @@ const participateTeam = async (
   const { teamId } = req.params;
 
   try {
-    const data = await teamService.participateTeam(participateTeamDto, +teamId);
+    const data = await teamService.participateTeam(+userId, +teamId);
 
     return res
       .status(statusCode.OK)

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -88,8 +88,7 @@ const getSocialUser = async (
 
 const getMyPage = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    // const userId = res.locals.JwtPayload;
-    const { userId } = req.params;
+    const userId = res.locals.JwtPayload;
     const data = await userService.getMyPage(+userId);
     return res
       .status(statusCode.OK)

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -86,4 +86,16 @@ const getSocialUser = async (
   }
 };
 
-export default { getSocialUser };
+const getMyPage = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    // const userId = res.locals.JwtPayload;
+    const { userId } = req.params;
+    const data = await userService.getMyPage(+userId);
+    return res
+      .status(statusCode.OK)
+      .send(success(statusCode.OK, message.READ_MYPAGE_SUCCESS, data));
+  } catch (error) {
+    next(error);
+  }
+};
+export default { getSocialUser, getMyPage };

--- a/src/interfaces/DTO.ts
+++ b/src/interfaces/DTO.ts
@@ -3,10 +3,6 @@ export interface createTeamDto {
   teamMember: number;
 }
 
-export interface participateTeamDto {
-  nickname: string;
-}
-
 export interface checkUserHappinessDto {
   isCompleted: boolean;
 }

--- a/src/modules/constants/responseMessage.ts
+++ b/src/modules/constants/responseMessage.ts
@@ -22,7 +22,7 @@ export default {
   READ_TEAM_RESULT_TYPE_SUCCESS: '팀 결과 조회 성공',
   READ_TEAM_DETAIL_RESULT_SUCCESS: '팀 결과 상세 조회 성공',
   READ_TEAM_INFO: '팀 정보 조회 성공',
-  MAKE_PERSONAL_RESULT_SUCCESS: '개인 결과 저장 성공',
+  READ_MYPAGE_SUCCESS: '지난 티타임 결과 보기 조회 성공',
 
   // 토큰
   CREATE_TOKEN_SUCCESS: '토큰 재발급 성공',

--- a/src/routers/chatRouter.ts
+++ b/src/routers/chatRouter.ts
@@ -6,14 +6,13 @@ import errorValidator from '../middleware/error/errorValidator';
 const router: Router = Router();
 
 router.post(
-  '/:userId',
+  '/',
   [
-    param('userId').notEmpty(),
-    body('questionType').notEmpty(),
-    body('questionNumber').notEmpty(),
-    body('answer').notEmpty().isLength({ max: 100 }),
-    body('grade').notEmpty(),
-    body('teamId').notEmpty(),
+    body('questionType').isString().notEmpty().isIn(['a', 'b', 'c', 'd', 'e']),
+    body('questionNumber').isNumeric().notEmpty().isIn([1, 2]),
+    body('answer').isString().notEmpty().isLength({ max: 100 }),
+    body('grade').isNumeric().notEmpty().isIn([1, 2, 3, 4, 5]),
+    body('teamId').isNumeric().notEmpty(),
   ],
   errorValidator,
   chatController.chatAnswer,

--- a/src/routers/resultRouter.ts
+++ b/src/routers/resultRouter.ts
@@ -35,10 +35,5 @@ router.patch(
   errorValidator,
   resultController.checkUserHappiness,
 );
-router.post(
-  '/personal',
-  errorValidator,
-  resultController.makePersonalResult,
-)
 
 export default router;

--- a/src/routers/resultRouter.ts
+++ b/src/routers/resultRouter.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { body, param, query } from 'express-validator';
 import { resultController } from '../controllers';
+import auth from '../middleware/auth';
 import errorValidator from '../middleware/error/errorValidator';
 
 const router: Router = Router();
@@ -30,9 +31,10 @@ router.get(
   resultController.getTeamDetailResult,
 );
 router.patch(
-  '/:userId',
-  [param('userId').notEmpty(), body('isCompleted').notEmpty()],
+  '/:teamId',
+  [param('teamId').notEmpty(), body('isCompleted').notEmpty()],
   errorValidator,
+  auth,
   resultController.checkUserHappiness,
 );
 

--- a/src/routers/teamRouter.ts
+++ b/src/routers/teamRouter.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 import { teamController } from '../controllers';
+import auth from '../middleware/auth';
 import errorValidator from '../middleware/error/errorValidator';
 
 const router: Router = Router();
@@ -8,10 +9,11 @@ const router: Router = Router();
 router.post(
   '/',
   [
-    body('teamName').notEmpty().isLength({ max: 14 }),
-    body('teamMember').notEmpty(),
+    body('teamName').isString().notEmpty().isLength({ max: 14 }),
+    body('teamMember').isNumeric().notEmpty(),
   ],
   errorValidator,
+  auth,
   teamController.makeTeam,
 );
 router.post(

--- a/src/routers/userRouter.ts
+++ b/src/routers/userRouter.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 import { userController } from '../controllers';
+import auth from '../middleware/auth';
 import errorValidator from '../middleware/error/errorValidator';
 
 const router: Router = Router();
@@ -10,5 +11,7 @@ router.post('/auth', [
   errorValidator,
   userController.getSocialUser,
 ]);
+
+router.get('/myPage/:userId', userController.getMyPage);
 
 export default router;

--- a/src/routers/userRouter.ts
+++ b/src/routers/userRouter.ts
@@ -12,6 +12,6 @@ router.post('/auth', [
   userController.getSocialUser,
 ]);
 
-router.get('/myPage/:userId', userController.getMyPage);
+router.get('/myPage', auth, userController.getMyPage);
 
 export default router;

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -14,7 +14,14 @@ const chatAnswer = async (userId: number, createAnswerDto: createAnswerDto) => {
         teamId: createAnswerDto.teamId,
       },
     });
-    return chat;
+    const data = {
+      questionType: chat.questionType,
+      questionNumber: chat.questionNumber,
+      answer: chat.answer,
+      grade: chat.grade,
+      teamId: chat.teamId,
+    };
+    return data;
   } catch (error) {
     throw error;
   }

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -6,7 +6,7 @@ const chatAnswer = async (userId: number, createAnswerDto: createAnswerDto) => {
   try {
     const chat = await prisma.chat.create({
       data: {
-        userId: userId,
+        userId,
         questionType: createAnswerDto.questionType,
         questionNumber: createAnswerDto.questionNumber,
         answer: createAnswerDto.answer,
@@ -16,7 +16,6 @@ const chatAnswer = async (userId: number, createAnswerDto: createAnswerDto) => {
     });
     return chat;
   } catch (error) {
-    console.log(error);
     throw error;
   }
 };

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -197,12 +197,14 @@ const getTeamDetailResult = async (teamId: number, type: string) => {
 
 const checkUserHappiness = async (
   userId: number,
+  teamId: number,
   checkUserHappinessDto: checkUserHappinessDto,
 ) => {
   try {
-    const data = await prisma.team_user.update({
+    const data = await prisma.team_user.updateMany({
       where: {
-        userId: userId,
+        userId,
+        teamId,
       },
       data: {
         isCompleted: checkUserHappinessDto.isCompleted,
@@ -216,8 +218,8 @@ const checkUserHappiness = async (
     }
 
     const result = {
-      userId: data.userId,
-      completed: data.isCompleted,
+      userId: userId,
+      isCompleted: checkUserHappinessDto.isCompleted,
     };
 
     return result;

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -1,4 +1,7 @@
-import { checkUserHappinessDto, makePersonalResultDto } from '../interfaces/DTO';
+import {
+  checkUserHappinessDto,
+  makePersonalResultDto,
+} from '../interfaces/DTO';
 import dayjs from 'dayjs';
 import { PrismaClient } from '@prisma/client';
 import errorGenerator from '../middleware/error/errorGenerator';
@@ -223,37 +226,10 @@ const checkUserHappiness = async (
   }
 };
 
-
-const makePersonalResult = async (
-  userId: number,
-  makePersonalResultDto: makePersonalResultDto,
-) => {
-  try {
-    const data = await prisma.personal_result.create({
-      data : {
-        userId: userId,
-        date: makePersonalResultDto.date,
-        teamName: makePersonalResultDto.teamName,
-        result: makePersonalResultDto.result,
-        collaboration: makePersonalResultDto.collaboration,
-        personalLife: makePersonalResultDto.personalLife,
-        health: makePersonalResultDto.health,
-        development: makePersonalResultDto.development,
-        motivation: makePersonalResultDto.motivation
-      }
-    });
-    return data;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-}
-
 export default {
   userResult,
   teamResultByType,
   getResultByType,
   getTeamDetailResult,
   checkUserHappiness,
-  makePersonalResult,
 };

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -18,28 +18,26 @@ const makeTeam = async (
         creatorId: userId,
       },
     });
+
+    //방장 추가
+    await prisma.team_user.create({
+      data: {
+        userId,
+        teamId,
+      },
+    });
     return team;
   } catch (error) {
     throw error;
   }
 };
 
-const participateTeam = async (
-  participateTeamDto: participateTeamDto,
-  teamId: number,
-) => {
+const participateTeam = async (userId: number, teamId: number) => {
   try {
-    const user = await prisma.user.create({
+    await prisma.team_user.create({
       data: {
-        name: participateTeamDto.nickname,
-      },
-    });
-
-    const joinTeam = await prisma.team_user.create({
-      data: {
-        userId: user.id,
-        teamId: teamId,
-        isCompleted: false,
+        userId,
+        teamId,
       },
     });
 
@@ -50,8 +48,8 @@ const participateTeam = async (
     });
 
     const data = {
-      userId: joinTeam.userId,
-      teamId: teamInfo?.id,
+      userId: userId,
+      teamId: teamId,
       teamName: teamInfo?.teamName,
     };
 

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -1,4 +1,4 @@
-import { createTeamDto, participateTeamDto } from '../interfaces/DTO';
+import { createTeamDto } from '../interfaces/DTO';
 import { PrismaClient } from '@prisma/client';
 import errorGenerator from '../middleware/error/errorGenerator';
 import { message, statusCode } from '../modules/constants';
@@ -107,36 +107,6 @@ const checkTeamHappiness = async (teamId: number) => {
     throw error;
   }
 };
-const duplicateName = async (
-  teamId: number,
-  participateTeamDto: participateTeamDto,
-) => {
-  try {
-    const data = await prisma.team_user.findFirst({
-      where: {
-        AND: [
-          {
-            teamId: teamId,
-          },
-          {
-            nickname: {
-              name: participateTeamDto.nickname,
-            },
-          },
-        ],
-      },
-    });
-    if (data) {
-      throw errorGenerator({
-        msg: message.DUPLICATE_NAME,
-        statusCode: statusCode.BAD_REQUEST,
-      });
-    }
-    return data;
-  } catch (error) {
-    throw error;
-  }
-};
 
 const getTeamInfo = async (teamId: number) => {
   try {
@@ -160,6 +130,5 @@ export default {
   makeTeam,
   participateTeam,
   checkTeamHappiness,
-  duplicateName,
   getTeamInfo,
 };

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -4,13 +4,18 @@ import errorGenerator from '../middleware/error/errorGenerator';
 import { message, statusCode } from '../modules/constants';
 const prisma = new PrismaClient();
 
-const makeTeam = async (createTeamDto: createTeamDto, teamId: number) => {
+const makeTeam = async (
+  userId: number,
+  createTeamDto: createTeamDto,
+  teamId: number,
+) => {
   try {
     const team = await prisma.team.create({
       data: {
         id: teamId,
         teamName: createTeamDto.teamName,
         teamMember: createTeamDto.teamMember,
+        creatorId: userId,
       },
     });
     return team;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -77,4 +77,48 @@ const updateRefreshToken = async (id: number, refreshToken: string) => {
   }
 };
 
-export default { getSocialUser, findUserById, signUpUser, updateRefreshToken };
+const getMyPage = async (userId: number) => {
+  try {
+    const userInfo = await prisma.team_user.findMany({
+      where: {
+        userId,
+      },
+      select: {
+        updatedAt: true,
+        user: {
+          select: {
+            name: true,
+          },
+        },
+        team: {
+          select: {
+            teamName: true,
+          },
+        },
+      },
+    });
+    const projectArray = await Promise.all(
+      userInfo.map((data: any) => {
+        const result = {
+          date: data.updatedAt,
+          teamName: data.team.teamName,
+        };
+        return result;
+      }),
+    );
+    const data = {
+      userName: userInfo[0].user.name,
+      history: projectArray,
+    };
+    return data;
+  } catch (error) {
+    throw error;
+  }
+};
+export default {
+  getSocialUser,
+  findUserById,
+  signUpUser,
+  updateRefreshToken,
+  getMyPage,
+};


### PR DESCRIPTION
## Solved Issue

close #82

<br>

## Motivation

- 지난 티타임 보기 조회 API를 구현합니다.
- auth 로직을 추가합니다.

<br>

## Key Changes

- 개인결과를 저장하는 API를 걷어냈습니다.
- auth로직을 추가하였습니다.
- 지난 티타임 보기 조회 API를 구현하였습니다.

![image](https://user-images.githubusercontent.com/82744423/222056068-1a1d79cf-92e7-49ee-835f-0773d31cb9e4.png)

<br>

## To Reviewers

- 코드 보고 궁금한 점이나 잘못된 점 있으면 피드백 부탁드려요!