### PR TITLE
fix: 소셜 로그인, 회원가입 시에 유저 이름 정보 반환 값 추가

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -57,6 +57,7 @@ const getSocialUser = async (
     const data = {
       signUp: true,
       accessToken: accessToken,
+      name: existUser.name,
     };
 
     return res
@@ -82,6 +83,7 @@ const getSocialUser = async (
 
     return {
       accessToken: accessToken,
+      name: newUser.name,
     };
   }
 };


### PR DESCRIPTION
## Solved Issue

close #86 

<br>

## Motivation

- 소셜 로그인, 회원가입 시에 온보딩 페이지에 필요한 유저 이름 정보를 반환하지 않고 있었습니다.

<br>

## Key Changes

- accessToken과 함께 유저의 이름 정보를 반환합니다.

<br>

## To Reviewers

- 확인해주시고 머지 부탁드려요!
