### PR TITLE
fix: 개인 결과 뷰 조회 & 팀 결과 점수 조회 중복 값 제거

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,13 +38,13 @@ model team_user {
   isCompleted Boolean   @default(false)
   createdAt   DateTime? @default(dbgenerated("CURRENT_DATE")) @db.Date
   updatedAt   DateTime? @updatedAt @db.Date
-  id          Int       @id @default(autoincrement())
+  id          Int       @id @unique @default(autoincrement())
   team        team      @relation(fields: [teamId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_team_id_fk")
-  user        user      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_nickname_id_fk")
+  user        user      @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "team_user_user_id_fk")
 }
 
 model user {
-  id           Int         @id @unique(map: "nickname_id_key") @default(autoincrement())
+  id           Int         @id @unique @default(autoincrement())
   name         String      @db.VarChar(4)
   createdAt    DateTime    @default(dbgenerated("CURRENT_DATE")) @db.Date
   updatedAt    DateTime?   @default(dbgenerated("CURRENT_DATE")) @db.Date

--- a/src/controllers/resultController.ts
+++ b/src/controllers/resultController.ts
@@ -8,10 +8,10 @@ import { success } from '../modules/constants/util';
 import { resultService } from '../services';
 
 const userResult = async (req: Request, res: Response, next: NextFunction) => {
-  const { userId } = req.params;
+  const { userId, teamId } = req.params;
 
   try {
-    const data = await resultService.userResult(+userId);
+    const data = await resultService.userResult(+userId, +teamId);
 
     return res
       .status(statusCode.OK)

--- a/src/routers/resultRouter.ts
+++ b/src/routers/resultRouter.ts
@@ -7,7 +7,7 @@ import errorValidator from '../middleware/error/errorValidator';
 const router: Router = Router();
 
 router.get(
-  '/:userId',
+  '/:userId/:teamId',
   [param('userId').notEmpty()],
   errorValidator,
   resultController.userResult,

--- a/src/services/resultService.ts
+++ b/src/services/resultService.ts
@@ -8,16 +8,16 @@ import errorGenerator from '../middleware/error/errorGenerator';
 import { message, statusCode } from '../modules/constants';
 const prisma = new PrismaClient();
 
-const userResult = async (userId: number) => {
+const userResult = async (userId: number, teamId: number) => {
   try {
     const findTeam = await prisma.team_user.findFirst({
       where: {
-        userId: userId,
+        userId,
+        teamId,
       },
       select: {
         user: true,
         team: true,
-        teamId: true,
       },
     });
     if (!findTeam) {

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -34,6 +34,18 @@ const makeTeam = async (
 
 const participateTeam = async (userId: number, teamId: number) => {
   try {
+    const duplicate = await prisma.team_user.findFirst({
+      where: {
+        userId,
+        teamId,
+      },
+    });
+    if (duplicate) {
+      throw errorGenerator({
+        msg: message.DUPLICATE_TEAM,
+        statusCode: statusCode.BAD_REQUEST,
+      });
+    }
     await prisma.team_user.create({
       data: {
         userId,


### PR DESCRIPTION
## Solved Issue

close #90 

<br>

## Motivation

- 개인 결과 뷰 조회 & 팀 결과 점수 조회 중복 값 제거

<br>

## Key Changes

- 개인 결과 뷰 조회 api에 teamId 추가
- query 조건에 teamId 추가
- 중복에 대한 에러처리 

<br>

## To Reviewers

- 확인하고 머지 부탁드려요!
