### PR TITLE
fix: 초대장 생성 시, 방장 추가 쿼리 삭제

### DIFF
--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -19,13 +19,6 @@ const makeTeam = async (
       },
     });
 
-    //방장 추가
-    await prisma.team_user.create({
-      data: {
-        userId,
-        teamId,
-      },
-    });
     return team;
   } catch (error) {
     throw error;


### PR DESCRIPTION
## Solved Issue

close #92 

<br>

## Motivation

- 초대장 생성 시, 방장을 유저에 등록하여 프론트 단에서 로직에 문제가 생깁니다.

<br>

## Key Changes

- 방장을 유저로 추가하는 쿼리를 삭제해주었습니다.

<br>

## To Reviewers

- 확인해주시고 머지 부탁드려요!
