### PR TITLE
fix: 마이페이지 조회 시 로직 수정 & 팀 결과 조회 시 로직 수정

### DIFF
--- a/src/routers/resultRouter.ts
+++ b/src/routers/resultRouter.ts
@@ -7,12 +7,6 @@ import errorValidator from '../middleware/error/errorValidator';
 const router: Router = Router();
 
 router.get(
-  '/:userId/:teamId',
-  [param('userId').notEmpty()],
-  errorValidator,
-  resultController.userResult,
-);
-router.get(
   '/team/score/:teamId',
   [param('teamId').notEmpty()],
   errorValidator,
@@ -36,6 +30,13 @@ router.patch(
   errorValidator,
   auth,
   resultController.checkUserHappiness,
+);
+
+router.get(
+  '/:userId/:teamId',
+  [param('userId').notEmpty()],
+  errorValidator,
+  resultController.userResult,
 );
 
 export default router;

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -101,12 +101,14 @@ const getMyPage = async (userId: number) => {
       userInfo.map((data: any) => {
         const result = {
           date: data.updatedAt,
+          teamId: data.team.id,
           teamName: data.team.teamName,
         };
         return result;
       }),
     );
     const data = {
+      userId: userId,
       userName: userInfo[0].user.name,
       history: projectArray,
     };


### PR DESCRIPTION
## Solved Issue

close #94 

<br>

## Motivation

- 마이 페이지 조회 시 teamId, userId를 반환하지 않고 있습니다.
- 팀 결과 조회 시 NaN 에러가 발생합니다.

<br>

## Key Changes

- 반환 값에 userId, teamId를 추가해주었습니다.
- 동적 파라미터로 인한 teamRouter 코드 순서를 수정해주었습니다.

<br>

## To Reviewers

- 확인해주시고 머지 부탁드려요!
