### PR TITLE
fix: 지난 티타임 결과 조회 시, 최신 순 정렬

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -97,6 +97,9 @@ const getMyPage = async (userId: number) => {
           },
         },
       },
+      orderBy: {
+        updatedAt: 'desc',
+      },
     });
     if (userInfo.length == 0) {
       const user = await prisma.user.findFirst({


### PR DESCRIPTION
## Solved Issue

close #102 

<br>

## Motivation

- 지난 티타임 결과 조회 시, 최신 순 정렬합니다.

<br>

## Key Changes

- userService 지난 티타임 결과 조회 시, 함수 로직 수정

<br>

## To Reviewers

- 확인해주시고 머지 부탁드려요!
