### PR TITLE
fix: 초대장으로 팀 입장 & 해피니스 체크 로직 수정

### DIFF
--- a/src/routers/chatRouter.ts
+++ b/src/routers/chatRouter.ts
@@ -6,7 +6,7 @@ import errorValidator from '../middleware/error/errorValidator';
 
 const router: Router = Router();
 
-router.post(
+router.put(
   '/',
   [
     body('questionType').isString().notEmpty().isIn(['a', 'b', 'c', 'd', 'e']),

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -4,6 +4,39 @@ const prisma = new PrismaClient();
 
 const chatAnswer = async (userId: number, createAnswerDto: createAnswerDto) => {
   try {
+    const check = await prisma.chat.findFirst({
+      where: {
+        userId,
+        teamId: createAnswerDto.teamId,
+        questionType: createAnswerDto.questionType,
+        questionNumber: createAnswerDto.questionNumber,
+      },
+    });
+    if (check) {
+      const chat = await prisma.chat.updateMany({
+        where: {
+          userId,
+          teamId: createAnswerDto.teamId,
+        },
+        data: {
+          userId,
+          questionType: createAnswerDto.questionType,
+          questionNumber: createAnswerDto.questionNumber,
+          answer: createAnswerDto.answer,
+          grade: createAnswerDto.grade,
+          teamId: createAnswerDto.teamId,
+        },
+      });
+
+      const data = {
+        questionType: createAnswerDto.questionType,
+        questionNumber: createAnswerDto.questionNumber,
+        answer: createAnswerDto.answer,
+        grade: createAnswerDto.grade,
+        teamId: createAnswerDto.teamId,
+      };
+      return data;
+    }
     const chat = await prisma.chat.create({
       data: {
         userId,
@@ -14,6 +47,7 @@ const chatAnswer = async (userId: number, createAnswerDto: createAnswerDto) => {
         teamId: createAnswerDto.teamId,
       },
     });
+
     const data = {
       questionType: chat.questionType,
       questionNumber: chat.questionNumber,

--- a/src/services/teamService.ts
+++ b/src/services/teamService.ts
@@ -32,12 +32,21 @@ const participateTeam = async (userId: number, teamId: number) => {
         userId,
         teamId,
       },
+      include: {
+        team: {
+          select: {
+            teamName: true,
+          },
+        },
+      },
     });
     if (duplicate) {
-      throw errorGenerator({
-        msg: message.DUPLICATE_TEAM,
-        statusCode: statusCode.BAD_REQUEST,
-      });
+      const data = {
+        userId: Buffer.from(String(userId), 'utf8').toString('base64'),
+        teamId: teamId,
+        teamName: duplicate?.team.teamName,
+      };
+      return data;
     }
     await prisma.team_user.create({
       data: {


### PR DESCRIPTION
## Solved Issue

close #110

<br>

## Motivation

- 채팅 답변을 전부 완료하지 않은 유저가 재입장을 못하는 문제가 발생합니다.
- 새로운 창이 열리면 채팅을 다시 시작해야 하므로 이미 진행되었을 시, 값을 덮어 씌우도록 합니다.

<br>

## Key Changes

- 초대장으로 팀 입장 시, 중복된 팀이 있을 경우 분기처리를 해주었습니다.
- 채팅이 이미 존재하면 update시키고, 없다면 create시키도록 하였습니다.  upsert를 활용하여 코드 길이를 줄이려고 하였으나, 조건문에 들어가는 값이 UserWhereUniqueInput하지 못하여 분기처리로 작성하였습니다. 좋은 방법이 있다면 말씀해주세요!

<br>

## To Reviewers

- 궁금한 점이나 피드백해주실 부분이 있다면 확인해주세요!
- 확인이 끝났다면 머지 부탁드려요!
